### PR TITLE
Fix testing of compilability of generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rflx linguist-language=Ada

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         echo "$HOME/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
+        echo "PYTEST_ADDOPTS=--basetemp=build" >> $GITHUB_ENV
     - name: Test
       run: |
         python3 -m pytest -n $(nproc) -vv

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -7,8 +7,5 @@ import pytest
 
 @pytest.mark.parametrize("spec", glob.glob("*.rflx"))
 def test_spec(spec: str, tmp_path: pathlib.Path) -> None:
-    print("start")
     subprocess.run(["rflx", "generate", "-d", tmp_path, spec], check=True)
-    print("gprbuild")
     subprocess.run(["gprbuild", "-U"], check=True, cwd=tmp_path)
-    print("done")


### PR DESCRIPTION
The compilability of the generated code was not tested before. The source code couldn't be found by `gprbuild`, as the used temporary directory was outside the Docker container in which `gprbuild` is executed.