### PR TITLE
Fix test of validation tool

### DIFF
--- a/tests/test_validation_tool.py
+++ b/tests/test_validation_tool.py
@@ -234,14 +234,14 @@ def test_cli_invalid_identifier() -> None:
                 "-s",
                 "tests/validation_tool/in_ethernet.rflx",
                 "-m",
-                "Ethernet.Frame",
+                "Ethernet Frame",
                 "-v",
                 "tests/validation_tool/ethernet/frame/valid",
                 "-i",
                 "tests/validation_tool/ethernet/frame/invalid",
             ]
         )
-        == 'invalid identifier "Ethernet.Frame" : id: error: "." in identifier parts'
+        == 'invalid identifier: id: error: " " in identifier parts of "Ethernet Frame"'
     )
 
 

--- a/tools/validate_spec.py
+++ b/tools/validate_spec.py
@@ -99,7 +99,7 @@ def cli(argv: List[str]) -> Union[int, str]:
     try:
         identifier = ID(args.message_identifier)
     except RecordFluxError as e:
-        return f'invalid identifier "{args.message_identifier}" : {e}'
+        return f"invalid identifier: {e}"
 
     try:
         pyrflx = PyRFLX.from_specs(


### PR DESCRIPTION
The test failed in the nightly tests, as the behavior of `ID` has changed after merging the PR in RecordFlux yesterday.